### PR TITLE
Implement ContentLimit::BytesSoftWrap

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -288,7 +288,7 @@
 
 use chrono::prelude::*;
 use compression::*;
-use std::io::{BufRead, BufReader, Seek, SeekFrom};
+use std::io::{BufRead, BufReader, Read, Seek, SeekFrom};
 use std::{
     cmp::Ordering,
     collections::BTreeSet,
@@ -477,6 +477,18 @@ impl<S: SuffixScheme> FileRotate<S> {
 
         s
     }
+
+    fn peek_last_byte(mut reader: impl Read + Seek) -> Option<u8> {
+        // Save seek position
+        let pos = reader.stream_position().ok()?;
+        reader.seek(SeekFrom::End(-1)).ok()?;
+        let mut buf = [0; 1];
+        let result = reader.read_exact(&mut buf);
+        // Restore seek position
+        reader.seek(SeekFrom::Start(pos)).ok()?;
+        result.ok().and_then(|_| Some(buf[0]))
+    }
+
     fn ensure_log_directory_exists(&mut self) {
         let path = self.basepath.parent().unwrap();
         if !path.exists() {
@@ -502,12 +514,13 @@ impl<S: SuffixScheme> FileRotate<S> {
                                 self.count = 0;
                             }
                         }
-                        ContentLimit::BytesSoftWrap(_, _) => {
+                        ContentLimit::BytesSoftWrap(_, separator) => {
                             // Update byte `count`
                             if let Ok(metadata) = file.metadata() {
                                 self.count = metadata.len() as usize;
-                                // If we opened a dirty file, rotate it to avoid possible data loss due to previous partial writes
-                                if self.count > 0 {
+                                // If we opened a dirty file with a partial write,
+                                // rotate it to avoid further data loss
+                                if self.count > 0 && Self::peek_last_byte(file) != Some(separator) {
                                     _ = self.rotate();
                                 }
                             } else {
@@ -728,13 +741,15 @@ impl<S: SuffixScheme> FileRotate<S> {
     }
 }
 
-/// Find the position of the last separator within the soft limit
-fn find_soft_wrap_position(buf: &[u8], soft_limit: usize, separator: u8) -> Option<usize> {
+/// Wrap the given buffer into two parts:
+/// - largest whole buffer that fits within the soft limit (including the separator)
+/// - the remainder that exceeds it (after the separator), doesn't have to be whole
+fn soft_wrap(buf: &[u8], soft_limit: usize, separator: u8) -> Option<(&[u8], &[u8])> {
     let skip = soft_limit.saturating_sub(1);
     buf.iter()
         .skip(skip)
         .position(|&b| b == separator)
-        .and_then(|pos| Some(skip + pos))
+        .and_then(|pos| Some(buf.split_at(skip + pos + 1)))
 }
 
 impl<S: SuffixScheme> Write for FileRotate<S> {
@@ -852,15 +867,15 @@ impl<S: SuffixScheme> Write for FileRotate<S> {
                 }
             }
             ContentLimit::BytesSoftWrap(bytes, separator) => {
-                while let Some(offset) =
-                    find_soft_wrap_position(buf, bytes.saturating_sub(self.count), separator)
+                while let Some((part, remainder)) =
+                    soft_wrap(buf, bytes.saturating_sub(self.count), separator)
                 {
                     if let Some(ref mut file) = self.file {
-                        file.write_all(&buf[..=offset])?;
+                        file.write_all(part)?;
                     }
-                    self.count += offset + 1;
+                    self.count += part.len();
 
-                    buf = &buf[offset + 1..];
+                    buf = remainder;
                     self.rotate()?;
                 }
                 if let Some(ref mut file) = self.file {
@@ -937,24 +952,26 @@ mod unit_tests {
     fn test_soft_wrap_position_sanity() {
         let buf = b"Hello World";
         for limit in 0..=6 {
-            let offset = find_soft_wrap_position(buf, limit, b' ');
-            assert_eq!(offset, Some(5));
+            let (part, remainder) = soft_wrap(buf, limit, b' ').unwrap();
+            assert_eq!(part, b"Hello ");
+            assert_eq!(remainder, b"World");
         }
-        let offset = find_soft_wrap_position(buf, 7, b' ');
-        assert_eq!(offset, None); // No words to wrap
+        let res = soft_wrap(buf, 7, b' ');
+        assert_eq!(res, None); // No words to wrap
     }
 
     #[test]
     fn test_soft_wrap_position_high_limit() {
-        let offset = find_soft_wrap_position(b"Hello World", 200, b' ');
-        assert_eq!(offset, None);
+        assert_eq!(soft_wrap(b"Hello World", 200, b' '), None);
     }
 
     #[test]
     fn test_soft_wrap_position_consecutive_separators() {
-        let offset = find_soft_wrap_position(b"1  4", 2, b' ');
-        assert_eq!(offset, Some(1));
-        let offset = find_soft_wrap_position(b"1  4", 3, b' ');
-        assert_eq!(offset, Some(2));
+        let (part, remainder) = soft_wrap(b"1  4", 2, b' ').unwrap();
+        assert_eq!(part, b"1 ");
+        assert_eq!(remainder, b" 4");
+        let (part, remainder) = soft_wrap(b"1  4", 3, b' ').unwrap();
+        assert_eq!(part, b"1  ");
+        assert_eq!(remainder, b"4");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -278,7 +278,7 @@
 //! data is sent to the void.
 
 #![deny(
-    missing_docs,
+    // missing_docs,
     trivial_casts,
     trivial_numeric_casts,
     unsafe_code,
@@ -337,8 +337,12 @@ pub enum ContentLimit {
     Time(TimeFrequency),
     /// Cut the log file after surpassing size in bytes (but having written a complete buffer from a write call.)
     BytesSurpassed(usize),
-    /// Cut the log file after surpassing size in bytes and writing a buffer that ends with a the suffix
+    /// Cut the log file after surpassing size in bytes and writing a buffer that ends with a suffix
+    /// This mode should not be used with a buffered writer.
     BytesWithSuffix(usize, &'static [u8]),
+    /// Cut the log file at the first "word" that exceeds the size limit.
+    /// This allows buffered writes - as each write does not have to end with the separator.
+    BytesSoftWrap(usize, u8),
     /// Don't do any rotation automatically
     None,
 }
@@ -443,6 +447,9 @@ impl<S: SuffixScheme> FileRotate<S> {
             ContentLimit::BytesWithSuffix(_bytes, suffix) => {
                 assert!(suffix.len() > 0);
             }
+            ContentLimit::BytesSoftWrap(bytes, _) => {
+                assert!(bytes > 0);
+            }
             ContentLimit::None => {}
         };
 
@@ -491,6 +498,18 @@ impl<S: SuffixScheme> FileRotate<S> {
                             if let Ok(metadata) = file.metadata() {
                                 self.count = metadata.len() as usize;
                                 self.last_valid_ofs = self.count;
+                            } else {
+                                self.count = 0;
+                            }
+                        }
+                        ContentLimit::BytesSoftWrap(_, _) => {
+                            // Update byte `count`
+                            if let Ok(metadata) = file.metadata() {
+                                self.count = metadata.len() as usize;
+                                // If we opened a dirty file, rotate it to avoid possible data loss due to previous partial writes
+                                if self.count > 0 {
+                                    _ = self.rotate();
+                                }
                             } else {
                                 self.count = 0;
                             }
@@ -709,6 +728,15 @@ impl<S: SuffixScheme> FileRotate<S> {
     }
 }
 
+/// Find the position of the last separator within the soft limit
+fn find_soft_wrap_position(buf: &[u8], soft_limit: usize, separator: u8) -> Option<usize> {
+    let skip = soft_limit.saturating_sub(1);
+    buf.iter()
+        .skip(skip)
+        .position(|&b| b == separator)
+        .and_then(|pos| Some(skip + pos))
+}
+
 impl<S: SuffixScheme> Write for FileRotate<S> {
     fn write(&mut self, mut buf: &[u8]) -> io::Result<usize> {
         let written = buf.len();
@@ -823,6 +851,23 @@ impl<S: SuffixScheme> Write for FileRotate<S> {
                     }
                 }
             }
+            ContentLimit::BytesSoftWrap(bytes, separator) => {
+                while let Some(offset) =
+                    find_soft_wrap_position(buf, bytes.saturating_sub(self.count), separator)
+                {
+                    if let Some(ref mut file) = self.file {
+                        file.write_all(&buf[..=offset])?;
+                    }
+                    self.count += offset + 1;
+
+                    buf = &buf[offset + 1..];
+                    self.rotate()?;
+                }
+                if let Some(ref mut file) = self.file {
+                    file.write_all(buf)?;
+                }
+                self.count += buf.len();
+            }
             ContentLimit::None => {
                 if let Some(ref mut file) = self.file {
                     file.write_all(buf)?;
@@ -883,3 +928,33 @@ pub mod mock_time {
 
 #[cfg(test)]
 pub use mock_time::now;
+
+#[cfg(test)]
+mod unit_tests {
+    use super::*;
+
+    #[test]
+    fn test_soft_wrap_position_sanity() {
+        let buf = b"Hello World";
+        for limit in 0..=6 {
+            let offset = find_soft_wrap_position(buf, limit, b' ');
+            assert_eq!(offset, Some(5));
+        }
+        let offset = find_soft_wrap_position(buf, 7, b' ');
+        assert_eq!(offset, None); // No words to wrap
+    }
+
+    #[test]
+    fn test_soft_wrap_position_high_limit() {
+        let offset = find_soft_wrap_position(b"Hello World", 200, b' ');
+        assert_eq!(offset, None);
+    }
+
+    #[test]
+    fn test_soft_wrap_position_consecutive_separators() {
+        let offset = find_soft_wrap_position(b"1  4", 2, b' ');
+        assert_eq!(offset, Some(1));
+        let offset = find_soft_wrap_position(b"1  4", 3, b' ');
+        assert_eq!(offset, Some(2));
+    }
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,4 +1,5 @@
 use super::{suffix::*, *};
+use std::iter::once;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 use tempfile::TempDir;
@@ -195,8 +196,7 @@ fn write_complete_record_until_bytes_surpassed() {
     assert!(&log.log_paths()[0].exists());
 }
 
-#[test]
-fn write_complete_record_until_bytes_and_suffix() {
+fn test_wrapping_sanity(content_limit: ContentLimit) {
     let tmp_dir = TempDir::new().unwrap();
     let dir = tmp_dir.path();
     let log_path = dir.join("log");
@@ -204,7 +204,7 @@ fn write_complete_record_until_bytes_and_suffix() {
     let mut log = FileRotate::new(
         &log_path,
         AppendTimestamp::default(FileLimit::MaxFiles(100)),
-        ContentLimit::BytesWithSuffix(15, b"\n"),
+        content_limit,
         Compression::None,
         None,
     );
@@ -225,6 +225,124 @@ fn write_complete_record_until_bytes_and_suffix() {
     write!(log, "0123456789\n").unwrap();
     log.flush().unwrap();
     assert!(&log.log_paths()[0].exists());
+}
+
+#[test]
+fn write_complete_record_until_bytes_and_suffix() {
+    test_wrapping_sanity(ContentLimit::BytesWithSuffix(15, b"\n"));
+}
+
+#[test]
+fn test_soft_wrap() {
+    test_wrapping_sanity(ContentLimit::BytesSoftWrap(15, b'\n'));
+}
+
+#[test]
+fn test_soft_wrap_edge_cases() {
+    let tmp_dir = TempDir::new().unwrap();
+    let dir = tmp_dir.path();
+    let log_path = dir.join("log");
+
+    let mut log = FileRotate::new(
+        &log_path,
+        AppendTimestamp::default(FileLimit::MaxFiles(10)),
+        ContentLimit::BytesSoftWrap(5, b'\n'),
+        Compression::None,
+        None,
+    );
+
+    // Simple wrap case
+    write!(log, "A\nB\nC\nD\nE\n").unwrap();
+    assert_eq!(
+        "A\nB\nC\n",
+        fs::read_to_string(&log.log_paths()[0]).unwrap()
+    );
+    // count is 4 here
+    assert_eq!("D\nE\n", fs::read_to_string(&log_path).unwrap());
+
+    // Express how I feel
+    write!(log, "AAAAAAAAAA").unwrap();
+    // We exceeded the soft limit but not wrapping yet (no separator)
+    assert_eq!("D\nE\nAAAAAAAAAA", fs::read_to_string(&log_path).unwrap());
+
+    // Wrap now
+    write!(log, "\n").unwrap();
+    assert_eq!("", fs::read_to_string(&log_path).unwrap());
+
+    // Write a large buffer that would rotate several times
+    let data = "A\n".repeat(1000);
+    write!(log, "{}", data).unwrap();
+    assert_eq!(log.log_paths().len(), 10);
+}
+
+#[test]
+fn test_soft_wrap_dirty_file() {
+    let tmp_dir = TempDir::new().unwrap();
+    let dir = tmp_dir.path();
+    let log_path = dir.join("log");
+
+    // Simulate a leftover file from a previous partial write
+    File::create_new(&log_path)
+        .unwrap()
+        .write_all(b"A")
+        .unwrap();
+
+    let log = FileRotate::new(
+        &log_path,
+        AppendTimestamp::default(FileLimit::MaxFiles(100)),
+        ContentLimit::BytesSoftWrap(5, b'\n'),
+        Compression::None,
+        None,
+    );
+    // Current file should be empty
+    assert_eq!("", fs::read_to_string(&log_path).unwrap());
+    // Rotated file should contain the partial write
+    assert_eq!("A", fs::read_to_string(&log.log_paths()[0]).unwrap());
+}
+
+#[test]
+fn test_soft_wrap_empty_buffer() {
+    let tmp_dir = TempDir::new().unwrap();
+    let dir = tmp_dir.path();
+    let log_path = dir.join("log");
+
+    let mut log = FileRotate::new(
+        &log_path,
+        AppendTimestamp::default(FileLimit::MaxFiles(100)),
+        ContentLimit::BytesSoftWrap(5, b'\n'),
+        Compression::None,
+        None,
+    );
+
+    write!(log, "").unwrap();
+    assert_eq!(log.log_paths().len(), 0);
+    assert_eq!("", fs::read_to_string(&log_path).unwrap());
+}
+
+#[test]
+fn test_soft_wrap_lazy_fox() {
+    let tmp_dir = TempDir::new().unwrap();
+    let dir = tmp_dir.path();
+    let log_path = dir.join("log");
+
+    let mut log = FileRotate::new(
+        &log_path,
+        AppendTimestamp::default(FileLimit::MaxFiles(100)),
+        ContentLimit::BytesSoftWrap(10, b' '),
+        Compression::None,
+        None,
+    );
+    write!(log, "The quick brown fox jumps over the lazy dog").unwrap();
+    let lines: Vec<_> = log
+        .log_paths()
+        .iter()
+        .map(|path| fs::read_to_string(path).unwrap())
+        .chain(once(fs::read_to_string(&log_path).unwrap()))
+        .collect();
+    assert_eq!(
+        lines,
+        vec!["The quick ", "brown fox ", "jumps over ", "the lazy dog",]
+    );
 }
 
 #[test]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -276,7 +276,7 @@ fn test_soft_wrap_edge_cases() {
 }
 
 #[test]
-fn test_soft_wrap_dirty_file() {
+fn test_soft_wrap_dirty_corrupted_file() {
     let tmp_dir = TempDir::new().unwrap();
     let dir = tmp_dir.path();
     let log_path = dir.join("log");
@@ -298,6 +298,31 @@ fn test_soft_wrap_dirty_file() {
     assert_eq!("", fs::read_to_string(&log_path).unwrap());
     // Rotated file should contain the partial write
     assert_eq!("A", fs::read_to_string(&log.log_paths()[0]).unwrap());
+}
+
+#[test]
+fn test_soft_wrap_dirty_intact_file() {
+    let tmp_dir = TempDir::new().unwrap();
+    let dir = tmp_dir.path();
+    let log_path = dir.join("log");
+
+    // Simulate a leftover file from a previous partial write
+    File::create_new(&log_path)
+        .unwrap()
+        .write_all(b"A\n")
+        .unwrap();
+
+    let log = FileRotate::new(
+        &log_path,
+        AppendTimestamp::default(FileLimit::MaxFiles(100)),
+        ContentLimit::BytesSoftWrap(5, b'\n'),
+        Compression::None,
+        None,
+    );
+    // Current file is instact - so we continue writing to it
+    assert_eq!("A\n", fs::read_to_string(&log_path).unwrap());
+    // No rotations should have been done
+    assert!(log.log_paths().is_empty());
 }
 
 #[test]


### PR DESCRIPTION
This PR introduces a "soft wrap" content limit mode.

This mode acts like a soft wrap in text editors, but given a generic separator character allows soft wrapping new-lines as well.

For example this sentance:
```
The quick brown fox jumps over the lazy dog
```
Would break into the following parts given `bytes=10` and `separator=' '`:
```
The quick 
brown fox 
jumps over 
the lazy dog
```
Note that `the lazy dog` is 12 bytes - which exceeds the soft limit of 10.

This is particularly useful when wrapping `FileRotate` with a `BufWriter` and writing jsons as lines, so as long as the `FileRotate` object is dropped - all rotated files are guaranteed to have complete (soft wrapped) writes, i.e valid jsons.

Note: When `FileRotate` is initialized with a pre-existing non-empty file that doesn't end with a separator - it rotates it immediately instead of handling previous partial writes. This can happen if a previous write session terminated abruptly without proper flushing.