### PR TITLE
suffix: Handle timestamp suffix collisions in rotate_file

### DIFF
--- a/src/suffix.rs
+++ b/src/suffix.rs
@@ -250,10 +250,15 @@ impl SuffixScheme for AppendTimestamp {
                 _ => {}
             };
 
-            let fmt_now = now.format(self.format).to_string();
+            let mut fmt_now = now.format(self.format).to_string();
 
             let number = if let Some(newest_suffix) = newest_suffix {
                 if newest_suffix.timestamp == fmt_now {
+                    Some(newest_suffix.number.unwrap_or(0) + 1)
+                } else if newest_suffix.timestamp > fmt_now {
+                    // Suffix collision (e.g. clock went backward)
+                    // Reuse the timestamp of the existing file and increment the number suffix
+                    fmt_now = newest_suffix.timestamp.clone();
                     Some(newest_suffix.number.unwrap_or(0) + 1)
                 } else {
                     None

--- a/src/suffix.rs
+++ b/src/suffix.rs
@@ -236,7 +236,7 @@ impl SuffixScheme for AppendTimestamp {
         newest_suffix: Option<&TimestampSuffix>,
         suffix: &Option<TimestampSuffix>,
     ) -> io::Result<TimestampSuffix> {
-        assert!(suffix.is_none());
+        debug_assert!(suffix.is_none());
         if suffix.is_none() {
             let mut now = now();
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -770,6 +770,47 @@ fn test_panic() {
     assert_eq!("0123", fs::read_to_string(&log_path).unwrap());
 }
 
+/// Backward clock jumps (e.g. NTP sync) must not panic or lose data.
+/// The suffix scheme reuses the newest known timestamp with an
+/// incremented number suffix to avoid collisions.
+#[test]
+fn timestamp_rotation_after_clock_skew() {
+    let tmp_dir = TempDir::new().unwrap();
+    let dir = tmp_dir.path();
+    let log_path = dir.join("log");
+
+    let t1 = get_fake_date_time("2026-02-17T06:14:04");
+    let t2 = get_fake_date_time("2026-02-17T06:14:10");
+
+    mock_time::set_mock_time(t1);
+    let mut log = FileRotate::new(
+        &log_path,
+        AppendTimestamp::default(FileLimit::MaxFiles(10)),
+        ContentLimit::None,
+        Compression::None,
+        None,
+    );
+
+    writeln!(log, "first").unwrap();
+    log.rotate().unwrap();
+
+    mock_time::set_mock_time(t2);
+    writeln!(log, "second").unwrap();
+    log.rotate().unwrap();
+
+    // Clock jumps backward — rotate twice to verify number keeps incrementing
+    mock_time::set_mock_time(t1);
+    writeln!(log, "third").unwrap();
+    log.rotate().unwrap();
+    writeln!(log, "fourth").unwrap();
+    log.rotate().unwrap();
+
+    assert_eq!("first\n", fs::read_to_string(dir.join("log.20260217T061404")).unwrap());
+    assert_eq!("second\n", fs::read_to_string(dir.join("log.20260217T061410")).unwrap());
+    assert_eq!("third\n", fs::read_to_string(dir.join("log.20260217T061410.1")).unwrap());
+    assert_eq!("fourth\n", fs::read_to_string(dir.join("log.20260217T061410.2")).unwrap());
+}
+
 fn get_fake_date_time(date_time: &str) -> DateTime<Local> {
     let date_obj = NaiveDateTime::parse_from_str(date_time, "%Y-%m-%dT%H:%M:%S");
 


### PR DESCRIPTION
When the system clock jumps backward — common on cloud VMs after an NTP sync — AppendTimestamp would generate a suffix that collides with an already-rotated file. This triggered a cascading rename into a code path that was never meant to be reached, causing a panic (assert!) in debug builds **and also in release!** (mistaken for debug_assert).

The fix is simple: if the current time is behind the newest known suffix, we reuse that suffix's timestamp and increment its number (e.g. .20260217T061410.1). This preserves strict lexical ordering and avoids any filesystem collision, at the cost of the rotated file carrying a slightly inaccurate timestamp label — an acceptable tradeoff since the alternative was crashing or notifying the channel about rotations of the same file multiple times.