### PR TITLE
Tolerate missing rotated files during cleanup

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -682,7 +682,12 @@ impl<S: SuffixScheme> FileRotate<S> {
         let mut result = Ok(());
         for (i, suffix) in self.suffixes.iter().enumerate().rev() {
             if self.suffix_scheme.too_old(&suffix.suffix, i) {
-                result = result.and(fs::remove_file(suffix.to_path(&self.basepath)));
+                let cur_result = match fs::remove_file(suffix.to_path(&self.basepath)) {
+                    Ok(()) => Ok(()),
+                    Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(()),
+                    Err(e) => Err(e),
+                };
+                result = result.and(cur_result);
                 youngest_old = Some((*suffix).clone());
             } else {
                 break;


### PR DESCRIPTION
When rotating, old suffixed files are removed as part of the cleanup phase. However, external best-effort cleaners (e.g. log sweepers, disk-pressure monitors) may have already deleted some of these rotated files before the library's own cleanup runs.

Previously this would surface a spurious NotFound error. Now, NotFound is silently ignored so that rotation proceeds without failing when an external process has already cleaned up the file on our behalf.